### PR TITLE
Add CORS headers to Django framework responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ django-jet==1.0.8
 feedparser==5.2.1
 django-filter==2.1.0
 whitenoise==4.1.2
+django-cors-headers==3.0.0

--- a/shop_your_links/settings.py
+++ b/shop_your_links/settings.py
@@ -45,9 +45,11 @@ INSTALLED_APPS = [
     'rest_framework.authtoken',
     'django_filters',
     'django_cleanup',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -79,6 +81,11 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'shop_your_links.wsgi.application'
 
+# https://github.com/ottoyiu/django-cors-headers
+# CORS_ORIGIN_ALLOW_ALL = True   
+CORS_ORIGIN_WHITELIST = [
+    "http://localhost:3000",
+]
 
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases


### PR DESCRIPTION
Fixes #18 

- Since frontend/backend are on different ports, CORS galore
- Sets up backend to accept requests from different origins/ports
- https://github.com/ottoyiu/django-cors-headers