### PR TITLE
Explicitly made the image field in LinkSerializer not required

### DIFF
--- a/internal/serializers.py
+++ b/internal/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from internal.models import Link, Event, Preference
 
 class LinkSerializer(serializers.ModelSerializer):
-    image = serializers.ImageField(use_url=False)
+    image = serializers.ImageField(required=False, allow_null=True, use_url=False)
 
     class Meta:
         model = Link


### PR DESCRIPTION
Allows POST requests to /api/links with the image field set to 'null.' Important for the Add Link functionality.